### PR TITLE
Add artist and venue pages

### DIFF
--- a/app/artists/[id]/page.tsx
+++ b/app/artists/[id]/page.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { CalendarDays, Clock, MapPin, Twitter, Instagram, Globe, ChevronRight, Ticket } from "lucide-react"
+import { artists, events } from "@/lib/data"
+import { Card, CardContent } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { Button } from "@/components/ui/button"
+
+export default function ArtistPage({ params }: { params: { id: string } }) {
+  const artist = artists.find((a) => a.id === params.id)
+  if (!artist) {
+    return <div className="container mx-auto px-4 py-8 text-center">Artist not found</div>
+  }
+
+  const relatedEvents = events.filter((e) => e.artistId === artist.id)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center mb-8">
+          <div className="h-48 w-48 mx-auto rounded-full overflow-hidden mb-4">
+            <img src={artist.image} alt={artist.name} className="object-cover h-full w-full" />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-2">{artist.name}</h1>
+          <p className="text-slate-300 max-w-2xl mx-auto mb-4">{artist.bio}</p>
+          <div className="flex justify-center space-x-4">
+            {artist.social.twitter && (
+              <Link href={artist.social.twitter} target="_blank" className="text-slate-300 hover:text-white">
+                <Twitter className="h-5 w-5" />
+              </Link>
+            )}
+            {artist.social.instagram && (
+              <Link href={artist.social.instagram} target="_blank" className="text-slate-300 hover:text-white">
+                <Instagram className="h-5 w-5" />
+              </Link>
+            )}
+            {artist.social.website && (
+              <Link href={artist.social.website} target="_blank" className="text-slate-300 hover:text-white">
+                <Globe className="h-5 w-5" />
+              </Link>
+            )}
+          </div>
+        </div>
+
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-white mb-3">Upcoming Community Events</h2>
+          <ul className="space-y-2">
+            {artist.communityEvents.map((ev) => (
+              <li key={ev.title}>
+                <Link href={ev.link} className="text-purple-400 hover:underline flex items-center" target="_blank">
+                  {ev.title}
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold text-white mb-4">Events Featuring {artist.name}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {relatedEvents.map((event) => (
+              <Link href={`/events/${event.id}`} key={event.id}>
+                <Card className="overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] bg-slate-800 border-slate-700">
+                  <div className="relative h-48 w-full">
+                    <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${event.image})` }} />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-900 to-transparent opacity-70" />
+                    <div className="absolute bottom-4 left-4 right-4">
+                      <div className="flex justify-between items-center">
+                        <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-xs font-medium">
+                          {event.category}
+                        </span>
+                        <span className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium">
+                          {event.price} ETH
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <CardContent className="p-4">
+                    <h3 className="text-xl font-bold text-white mb-2">{event.name}</h3>
+                    <div className="flex items-center text-slate-400 text-sm mb-2">
+                      <CalendarDays className="h-4 w-4 mr-1" />
+                      <span>{event.date}</span>
+                      <Clock className="h-4 w-4 ml-3 mr-1" />
+                      <span>{event.time}</span>
+                    </div>
+                    <div className="flex items-center text-slate-400 text-sm mb-4">
+                      <MapPin className="h-4 w-4 mr-1" />
+                      <span>{event.location}</span>
+                    </div>
+                    <div className="mb-1 flex justify-between text-xs text-slate-400">
+                      <span>
+                        Tickets sold: {event.soldTickets}/{event.totalTickets}
+                      </span>
+                      <span>{Math.round((event.soldTickets / event.totalTickets) * 100)}%</span>
+                    </div>
+                    <Progress value={(event.soldTickets / event.totalTickets) * 100} className="h-2 bg-slate-700" />
+                    <div className="mt-4 flex justify-between items-center">
+                      <div className="flex items-center text-slate-300">
+                        <Ticket className="h-4 w-4 mr-1" />
+                        <span className="text-sm">{event.totalTickets - event.soldTickets} available</span>
+                      </div>
+                      <Button size="sm" variant="secondary" className="bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:from-purple-600 hover:to-pink-600">
+                        View Event
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useWallet } from "@/context/wallet-context"
 import { ConnectWalletModal } from "@/components/connect-wallet-modal"
 import { useToast } from "@/components/ui/use-toast"
 import { CalendarDays, Clock, MapPin, Ticket, Users, ChevronRight, Info, Share2 } from "lucide-react"
+import { events } from "@/lib/data"
 
 export default function EventPage({ params }: { params: { id: string } }) {
   const router = useRouter()
@@ -208,77 +209,3 @@ export default function EventPage({ params }: { params: { id: string } }) {
   )
 }
 
-const events = [
-  {
-    id: "1",
-    name: "Blockchain Summit 2023",
-    date: "June 15, 2023",
-    time: "10:00 AM",
-    location: "San Francisco, CA",
-    category: "Conference",
-    price: 0.15,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 156,
-    totalTickets: 200,
-  },
-  {
-    id: "2",
-    name: "NFT Art Exhibition",
-    date: "July 22, 2023",
-    time: "6:00 PM",
-    location: "New York, NY",
-    category: "Exhibition",
-    price: 0.08,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 89,
-    totalTickets: 150,
-  },
-  {
-    id: "3",
-    name: "Web3 Music Festival",
-    date: "August 5, 2023",
-    time: "4:00 PM",
-    location: "Miami, FL",
-    category: "Festival",
-    price: 0.25,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 412,
-    totalTickets: 500,
-  },
-  {
-    id: "4",
-    name: "DeFi Developer Conference",
-    date: "September 10, 2023",
-    time: "9:00 AM",
-    location: "Austin, TX",
-    category: "Conference",
-    price: 0.12,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 78,
-    totalTickets: 300,
-  },
-  {
-    id: "5",
-    name: "Metaverse Concert",
-    date: "October 18, 2023",
-    time: "8:00 PM",
-    location: "Los Angeles, CA",
-    category: "Concert",
-    price: 0.18,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 245,
-    totalTickets: 400,
-  },
-  {
-    id: "6",
-    name: "Crypto Gaming Tournament",
-    date: "November 25, 2023",
-    time: "2:00 PM",
-    location: "Seattle, WA",
-    category: "Gaming",
-    price: 0.05,
-    image: "/placeholder.svg?height=400&width=600",
-    soldTickets: 120,
-    totalTickets: 250,
-  },
-]

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { CalendarDays, Clock, MapPin, Ticket } from "lucide-react"
+import { artists, venues, events } from "@/lib/data"
 
 export default function Home() {
   return (
@@ -15,6 +16,38 @@ export default function Home() {
           <p className="text-slate-300 max-w-2xl mx-auto">
             Purchase tickets as NFTs for your favorite events. Secure, transferable, and always authentic.
           </p>
+        </div>
+
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold text-white mb-4">Artists & Venues</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {artists.map((artist) => (
+              <Link href={`/artists/${artist.id}`} key={artist.id}>
+                <Card className="overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] bg-slate-800 border-slate-700">
+                  <div className="relative h-40 w-full">
+                    <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${artist.image})` }} />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-900 to-transparent opacity-70" />
+                    <div className="absolute bottom-3 left-3 right-3 text-white font-semibold text-lg">
+                      {artist.name}
+                    </div>
+                  </div>
+                </Card>
+              </Link>
+            ))}
+            {venues.map((venue) => (
+              <Link href={`/venues/${venue.id}`} key={venue.id}>
+                <Card className="overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] bg-slate-800 border-slate-700">
+                  <div className="relative h-40 w-full">
+                    <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${venue.image})` }} />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-900 to-transparent opacity-70" />
+                    <div className="absolute bottom-3 left-3 right-3 text-white font-semibold text-lg">
+                      {venue.name}
+                    </div>
+                  </div>
+                </Card>
+              </Link>
+            ))}
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -80,77 +113,3 @@ export default function Home() {
   )
 }
 
-const events = [
-  {
-    id: "1",
-    name: "Blockchain Summit 2023",
-    date: "June 15, 2023",
-    time: "10:00 AM",
-    location: "San Francisco, CA",
-    category: "Conference",
-    price: 0.15,
-    image: "https://www.cryptotimes.io/wp-content/uploads/2025/03/DC-BLOCKCHAIN-SUMMIT-2025.jpg",
-    soldTickets: 156,
-    totalTickets: 200,
-  },
-  {
-    id: "2",
-    name: "NFT Art Exhibition",
-    date: "July 22, 2023",
-    time: "6:00 PM",
-    location: "New York, NY",
-    category: "Exhibition",
-    price: 0.08,
-    image: "https://www.tokyoweekender.com/wp-content/uploads/2021/07/CrypTOKYO-Press-Preview-and-VIP-invite-2-1.jpg",
-    soldTickets: 89,
-    totalTickets: 150,
-  },
-  {
-    id: "3",
-    name: "Web3 Music Festival",
-    date: "August 5, 2023",
-    time: "4:00 PM",
-    location: "Miami, FL",
-    category: "Festival",
-    price: 0.25,
-    image: "https://www.billboard.com/wp-content/uploads/2022/03/BILLBOARD-BLOCKCHAIN-02-b-Explainer-Shira-Inbar-1548.jpg?w=681&h=383&crop=1",
-    soldTickets: 412,
-    totalTickets: 500,
-  },
-  {
-    id: "4",
-    name: "DeFi Developer Conference",
-    date: "September 10, 2023",
-    time: "9:00 AM",
-    location: "Austin, TX",
-    category: "Conference",
-    price: 0.12,
-    image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSuAdxCvhlZ3iQmT_guNOl6ipJ3SoFpKDvYjT9l4YTIgMFrCA6rzn2M7uIv1__7rjjLzTI&usqp=CAU",
-    soldTickets: 78,
-    totalTickets: 300,
-  },
-  {
-    id: "5",
-    name: "Metaverse Concert",
-    date: "October 18, 2023",
-    time: "8:00 PM",
-    location: "Los Angeles, CA",
-    category: "Concert",
-    price: 0.18,
-    image: "https://images.theconversation.com/files/414962/original/file-20210806-17-jibbct.jpg?ixlib=rb-4.1.0&rect=0%2C5%2C2000%2C1116&q=20&auto=format&w=320&fit=clip&dpr=2&usm=12&cs=strip",
-    soldTickets: 245,
-    totalTickets: 400,
-  },
-  {
-    id: "6",
-    name: "Crypto Gaming Tournament",
-    date: "November 25, 2023",
-    time: "2:00 PM",
-    location: "Seattle, WA",
-    category: "Gaming",
-    price: 0.05,
-    image: "https://venturebeat.com/wp-content/uploads/2021/03/article23-1.jpg",
-    soldTickets: 120,
-    totalTickets: 250,
-  },
-]

--- a/app/venues/[id]/page.tsx
+++ b/app/venues/[id]/page.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import Link from "next/link"
+import { CalendarDays, Clock, MapPin, Twitter, Instagram, Globe, ChevronRight, Ticket } from "lucide-react"
+import { venues, events } from "@/lib/data"
+import { Card, CardContent } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { Button } from "@/components/ui/button"
+
+export default function VenuePage({ params }: { params: { id: string } }) {
+  const venue = venues.find((v) => v.id === params.id)
+  if (!venue) {
+    return <div className="container mx-auto px-4 py-8 text-center">Venue not found</div>
+  }
+
+  const relatedEvents = events.filter((e) => e.venueId === venue.id)
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800">
+      <div className="container mx-auto px-4 py-8">
+        <div className="text-center mb-8">
+          <div className="h-48 w-48 mx-auto rounded-lg overflow-hidden mb-4">
+            <img src={venue.image} alt={venue.name} className="object-cover h-full w-full" />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-2">{venue.name}</h1>
+          <p className="text-slate-300 max-w-2xl mx-auto mb-4">{venue.bio}</p>
+          <div className="flex justify-center space-x-4">
+            {venue.social.twitter && (
+              <Link href={venue.social.twitter} target="_blank" className="text-slate-300 hover:text-white">
+                <Twitter className="h-5 w-5" />
+              </Link>
+            )}
+            {venue.social.instagram && (
+              <Link href={venue.social.instagram} target="_blank" className="text-slate-300 hover:text-white">
+                <Instagram className="h-5 w-5" />
+              </Link>
+            )}
+            {venue.social.website && (
+              <Link href={venue.social.website} target="_blank" className="text-slate-300 hover:text-white">
+                <Globe className="h-5 w-5" />
+              </Link>
+            )}
+          </div>
+        </div>
+
+        <div className="mb-8">
+          <h2 className="text-xl font-semibold text-white mb-3">Upcoming Community Events</h2>
+          <ul className="space-y-2">
+            {venue.communityEvents.map((ev) => (
+              <li key={ev.title}>
+                <Link href={ev.link} className="text-purple-400 hover:underline flex items-center" target="_blank">
+                  {ev.title}
+                  <ChevronRight className="ml-1 h-4 w-4" />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold text-white mb-4">Events at {venue.name}</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {relatedEvents.map((event) => (
+              <Link href={`/events/${event.id}`} key={event.id}>
+                <Card className="overflow-hidden hover:shadow-lg transition-all duration-300 hover:scale-[1.02] bg-slate-800 border-slate-700">
+                  <div className="relative h-48 w-full">
+                    <div className="absolute inset-0 bg-cover bg-center" style={{ backgroundImage: `url(${event.image})` }} />
+                    <div className="absolute inset-0 bg-gradient-to-t from-slate-900 to-transparent opacity-70" />
+                    <div className="absolute bottom-4 left-4 right-4">
+                      <div className="flex justify-between items-center">
+                        <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-xs font-medium">
+                          {event.category}
+                        </span>
+                        <span className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium">
+                          {event.price} ETH
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <CardContent className="p-4">
+                    <h3 className="text-xl font-bold text-white mb-2">{event.name}</h3>
+                    <div className="flex items-center text-slate-400 text-sm mb-2">
+                      <CalendarDays className="h-4 w-4 mr-1" />
+                      <span>{event.date}</span>
+                      <Clock className="h-4 w-4 ml-3 mr-1" />
+                      <span>{event.time}</span>
+                    </div>
+                    <div className="flex items-center text-slate-400 text-sm mb-4">
+                      <MapPin className="h-4 w-4 mr-1" />
+                      <span>{event.location}</span>
+                    </div>
+                    <div className="mb-1 flex justify-between text-xs text-slate-400">
+                      <span>
+                        Tickets sold: {event.soldTickets}/{event.totalTickets}
+                      </span>
+                      <span>{Math.round((event.soldTickets / event.totalTickets) * 100)}%</span>
+                    </div>
+                    <Progress value={(event.soldTickets / event.totalTickets) * 100} className="h-2 bg-slate-700" />
+                    <div className="mt-4 flex justify-between items-center">
+                      <div className="flex items-center text-slate-300">
+                        <Ticket className="h-4 w-4 mr-1" />
+                        <span className="text-sm">{event.totalTickets - event.soldTickets} available</span>
+                      </div>
+                      <Button size="sm" variant="secondary" className="bg-gradient-to-r from-purple-500 to-pink-500 text-white hover:from-purple-600 hover:to-pink-600">
+                        View Event
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,190 @@
+export interface Event {
+  id: string
+  name: string
+  date: string
+  time: string
+  location: string
+  category: string
+  price: number
+  image: string
+  soldTickets: number
+  totalTickets: number
+  artistId: string
+  venueId: string
+}
+
+export interface CommunityEvent {
+  title: string
+  link: string
+}
+
+export interface Artist {
+  id: string
+  name: string
+  image: string
+  bio: string
+  social: {
+    twitter?: string
+    instagram?: string
+    website?: string
+  }
+  communityEvents: CommunityEvent[]
+}
+
+export interface Venue {
+  id: string
+  name: string
+  image: string
+  bio: string
+  social: {
+    twitter?: string
+    instagram?: string
+    website?: string
+  }
+  communityEvents: CommunityEvent[]
+}
+
+export const artists: Artist[] = [
+  {
+    id: "a1",
+    name: "DJ Crypto",
+    image: "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4",
+    bio: "DJ Crypto is a pioneer in blending electronic music with blockchain themes, energizing crowds worldwide.",
+    social: {
+      twitter: "https://twitter.com",
+      instagram: "https://instagram.com",
+    },
+    communityEvents: [
+      { title: "AMA with DJ Crypto", link: "https://example.com/ama" },
+      { title: "Community Remix Contest", link: "https://example.com/remix" },
+    ],
+  },
+  {
+    id: "a2",
+    name: "NFT Artists Collective",
+    image: "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e",
+    bio: "A group of digital creators pushing the boundaries of art and technology.",
+    social: {
+      twitter: "https://twitter.com",
+      website: "https://example.com",
+    },
+    communityEvents: [
+      { title: "Monthly Art Drop", link: "https://example.com/drop" },
+    ],
+  },
+]
+
+export const venues: Venue[] = [
+  {
+    id: "v1",
+    name: "Metaverse Arena",
+    image: "https://images.unsplash.com/photo-1559767948-1f383c6ab3c0",
+    bio: "A state-of-the-art virtual venue hosting immersive events in the metaverse.",
+    social: {
+      website: "https://example.com",
+    },
+    communityEvents: [
+      { title: "Virtual Tour", link: "https://example.com/tour" },
+    ],
+  },
+  {
+    id: "v2",
+    name: "Blockchain Center",
+    image: "https://images.unsplash.com/photo-1509099836639-18ba3b9947a6",
+    bio: "The hub for all things blockchain, offering conferences and hackathons year round.",
+    social: {
+      twitter: "https://twitter.com",
+      website: "https://example.com",
+    },
+    communityEvents: [
+      { title: "Weekly Meetup", link: "https://example.com/meet" },
+    ],
+  },
+]
+
+export const events: Event[] = [
+  {
+    id: "1",
+    name: "Blockchain Summit 2023",
+    date: "June 15, 2023",
+    time: "10:00 AM",
+    location: "San Francisco, CA",
+    category: "Conference",
+    price: 0.15,
+    image: "https://www.cryptotimes.io/wp-content/uploads/2025/03/DC-BLOCKCHAIN-SUMMIT-2025.jpg",
+    soldTickets: 156,
+    totalTickets: 200,
+    artistId: "a2",
+    venueId: "v2",
+  },
+  {
+    id: "2",
+    name: "NFT Art Exhibition",
+    date: "July 22, 2023",
+    time: "6:00 PM",
+    location: "New York, NY",
+    category: "Exhibition",
+    price: 0.08,
+    image: "https://www.tokyoweekender.com/wp-content/uploads/2021/07/CrypTOKYO-Press-Preview-and-VIP-invite-2-1.jpg",
+    soldTickets: 89,
+    totalTickets: 150,
+    artistId: "a2",
+    venueId: "v2",
+  },
+  {
+    id: "3",
+    name: "Web3 Music Festival",
+    date: "August 5, 2023",
+    time: "4:00 PM",
+    location: "Miami, FL",
+    category: "Festival",
+    price: 0.25,
+    image: "https://www.billboard.com/wp-content/uploads/2022/03/BILLBOARD-BLOCKCHAIN-02-b-Explainer-Shira-Inbar-1548.jpg?w=681&h=383&crop=1",
+    soldTickets: 412,
+    totalTickets: 500,
+    artistId: "a1",
+    venueId: "v1",
+  },
+  {
+    id: "4",
+    name: "DeFi Developer Conference",
+    date: "September 10, 2023",
+    time: "9:00 AM",
+    location: "Austin, TX",
+    category: "Conference",
+    price: 0.12,
+    image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSuAdxCvhlZ3iQmT_guNOl6ipJ3SoFpKDvYjT9l4YTIgMFrCA6rzn2M7uIv1__7rjjLzTI&usqp=CAU",
+    soldTickets: 78,
+    totalTickets: 300,
+    artistId: "a2",
+    venueId: "v2",
+  },
+  {
+    id: "5",
+    name: "Metaverse Concert",
+    date: "October 18, 2023",
+    time: "8:00 PM",
+    location: "Los Angeles, CA",
+    category: "Concert",
+    price: 0.18,
+    image: "https://images.theconversation.com/files/414962/original/file-20210806-17-jibbct.jpg?ixlib=rb-4.1.0&rect=0%2C5%2C2000%2C1116&q=20&auto=format&w=320&fit=clip&dpr=2&usm=12&cs=strip",
+    soldTickets: 245,
+    totalTickets: 400,
+    artistId: "a1",
+    venueId: "v1",
+  },
+  {
+    id: "6",
+    name: "Crypto Gaming Tournament",
+    date: "November 25, 2023",
+    time: "2:00 PM",
+    location: "Seattle, WA",
+    category: "Gaming",
+    price: 0.05,
+    image: "https://venturebeat.com/wp-content/uploads/2021/03/article23-1.jpg",
+    soldTickets: 120,
+    totalTickets: 250,
+    artistId: "a1",
+    venueId: "v2",
+  },
+]


### PR DESCRIPTION
## Summary
- share data in `lib/data.ts` for events, artists and venues
- feature artists and venues on the homepage
- add artist and venue detail pages
- update event page to use shared data

## Testing
- `pnpm lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_b_685d2d4e2e048328bd1dfb94fd0c7b3f