### PR TITLE
Display ticket pricing in USD with crypto option

### DIFF
--- a/app/artists/[id]/page.tsx
+++ b/app/artists/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { CalendarDays, Clock, MapPin, Twitter, Instagram, Globe, Ticket } from "lucide-react"
 import { artists, events } from "@/lib/data"
+import { Price } from "@/components/price"
 import { Card, CardContent } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
@@ -87,9 +88,11 @@ export default function ArtistPage({ params }: { params: { id: string } }) {
                           <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-xs font-medium">
                             {event.category}
                           </span>
-                          <span className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium">
-                            {event.price} ETH
-                          </span>
+                          <Price
+                            usd={event.priceUsd}
+                            eth={event.priceEth}
+                            className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium"
+                          />
                         </div>
                       </div>
                     </div>

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -11,6 +11,7 @@ import { ConnectWalletModal } from "@/components/connect-wallet-modal"
 import { useToast } from "@/components/ui/use-toast"
 import { CalendarDays, Clock, MapPin, Ticket, Users, ChevronRight, Info, Share2 } from "lucide-react"
 import { events } from "@/lib/data"
+import { Price } from "@/components/price"
 
 export default function EventPage({ params }: { params: { id: string } }) {
   const router = useRouter()
@@ -48,6 +49,9 @@ export default function EventPage({ params }: { params: { id: string } }) {
       description: "Sharing functionality would be implemented here",
     })
   }
+
+  const feeUsd = 6
+  const feeEth = 0.002
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800">
@@ -130,7 +134,9 @@ export default function EventPage({ params }: { params: { id: string } }) {
           <div>
             <Card className="bg-slate-800 border-slate-700 sticky top-20">
               <CardContent className="p-6">
-                <div className="text-2xl font-bold text-white mb-2">{event.price} ETH</div>
+                <div className="text-2xl font-bold text-white mb-2">
+                  <Price usd={event.priceUsd} eth={event.priceEth} />
+                </div>
                 <div className="text-sm text-slate-400 mb-4">per ticket</div>
 
                 <div className="mb-1 flex justify-between text-xs text-slate-400">
@@ -169,16 +175,26 @@ export default function EventPage({ params }: { params: { id: string } }) {
                 <div className="mb-6">
                   <div className="flex justify-between text-slate-300 mb-2">
                     <span>Subtotal</span>
-                    <span>{(event.price * quantity).toFixed(2)} ETH</span>
+                    <span>
+                      {isConnected
+                        ? `$${(event.priceUsd * quantity).toFixed(2)} / ${(event.priceEth * quantity).toFixed(3)} ETH`
+                        : `$${(event.priceUsd * quantity).toFixed(2)}`}
+                    </span>
                   </div>
                   <div className="flex justify-between text-slate-300 mb-2">
-                    <span>Gas fee (est.)</span>
-                    <span>0.002 ETH</span>
+                    <span>Transaction fee (est.)</span>
+                    <span>
+                      {isConnected ? `$${feeUsd} / ${feeEth} ETH` : `$${feeUsd}`}
+                    </span>
                   </div>
                   <Separator className="my-2 bg-slate-700" />
                   <div className="flex justify-between text-white font-semibold">
                     <span>Total</span>
-                    <span>{(event.price * quantity + 0.002).toFixed(3)} ETH</span>
+                    <span>
+                      {isConnected
+                        ? `$${(event.priceUsd * quantity + feeUsd).toFixed(2)} / ${(event.priceEth * quantity + feeEth).toFixed(3)} ETH`
+                        : `$${(event.priceUsd * quantity + feeUsd).toFixed(2)}`}
+                    </span>
                   </div>
                 </div>
 

--- a/app/events/[id]/purchase/page.tsx
+++ b/app/events/[id]/purchase/page.tsx
@@ -10,6 +10,7 @@ import { useToast } from "@/components/ui/use-toast"
 import { ArrowLeft, CreditCard, Wallet, Check, Loader2, ExternalLink } from "lucide-react"
 import { ethers } from "ethers"
 import MyNFTAbi from "@/artifacts/contracts/MyNFT.sol/MyNFT.json"
+import { Price } from "@/components/price"
 
 export default function PurchasePage({ params }: { params: { id: string } }) {
   const router = useRouter()
@@ -24,6 +25,8 @@ export default function PurchasePage({ params }: { params: { id: string } }) {
 
   // Find event by ID (in a real app, this would be fetched from an API)
   const event = events.find((e) => e.id === params.id)
+  const feeUsd = 6
+  const feeEth = 0.002
 
   useEffect(() => {
     // Get quantity from URL params
@@ -253,18 +256,26 @@ export default function PurchasePage({ params }: { params: { id: string } }) {
                 <div className="border-t border-slate-700 pt-4 mt-4">
                   <div className="flex justify-between text-slate-300 mb-2">
                     <span>Tickets ({quantity})</span>
-                    <span>{(event.price * quantity).toFixed(2)} ETH</span>
+                    <span>
+                      {isConnected
+                        ? `$${(event.priceUsd * quantity).toFixed(2)} / ${(event.priceEth * quantity).toFixed(3)} ETH`
+                        : `$${(event.priceUsd * quantity).toFixed(2)}`}
+                    </span>
                   </div>
 
                   <div className="flex justify-between text-slate-300 mb-2">
-                    <span>Gas fee (est.)</span>
-                    <span>0.002 ETH</span>
+                    <span>Transaction fee (est.)</span>
+                    <span>{isConnected ? `$${feeUsd} / ${feeEth} ETH` : `$${feeUsd}`}</span>
                   </div>
 
                   <div className="border-t border-slate-700 pt-2 mt-2">
                     <div className="flex justify-between text-white font-semibold">
                       <span>Total</span>
-                      <span>{(event.price * quantity + 0.002).toFixed(3)} ETH</span>
+                      <span>
+                        {isConnected
+                          ? `$${(event.priceUsd * quantity + feeUsd).toFixed(2)} / ${(event.priceEth * quantity + feeEth).toFixed(3)} ETH`
+                          : `$${(event.priceUsd * quantity + feeUsd).toFixed(2)}`}
+                      </span>
                     </div>
                   </div>
                 </div>
@@ -312,7 +323,8 @@ const events = [
     time: "10:00 AM",
     location: "San Francisco, CA",
     category: "Conference",
-    price: 0.15,
+    priceUsd: 450,
+    priceEth: 0.15,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 156,
     totalTickets: 200,
@@ -324,7 +336,8 @@ const events = [
     time: "6:00 PM",
     location: "New York, NY",
     category: "Exhibition",
-    price: 0.08,
+    priceUsd: 240,
+    priceEth: 0.08,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 89,
     totalTickets: 150,
@@ -336,7 +349,8 @@ const events = [
     time: "4:00 PM",
     location: "Miami, FL",
     category: "Festival",
-    price: 0.25,
+    priceUsd: 750,
+    priceEth: 0.25,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 412,
     totalTickets: 500,
@@ -348,7 +362,8 @@ const events = [
     time: "9:00 AM",
     location: "Austin, TX",
     category: "Conference",
-    price: 0.12,
+    priceUsd: 360,
+    priceEth: 0.12,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 78,
     totalTickets: 300,
@@ -360,7 +375,8 @@ const events = [
     time: "8:00 PM",
     location: "Los Angeles, CA",
     category: "Concert",
-    price: 0.18,
+    priceUsd: 540,
+    priceEth: 0.18,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 245,
     totalTickets: 400,
@@ -372,7 +388,8 @@ const events = [
     time: "2:00 PM",
     location: "Seattle, WA",
     category: "Gaming",
-    price: 0.05,
+    priceUsd: 150,
+    priceEth: 0.05,
     image: "/placeholder.svg?height=400&width=600",
     soldTickets: 120,
     totalTickets: 250,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { CalendarDays, Clock, MapPin, Ticket } from "lucide-react"
 import { artists, venues, events } from "@/lib/data"
+import { Price } from "@/components/price"
 
 export default function Home() {
   return (
@@ -60,9 +61,11 @@ export default function Home() {
                       <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-xs font-medium">
                         {event.category}
                       </span>
-                      <span className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium">
-                        {event.price} ETH
-                      </span>
+                      <Price
+                        usd={event.priceUsd}
+                        eth={event.priceEth}
+                        className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium"
+                      />
                     </div>
                   </div>
                 </div>

--- a/app/venues/[id]/page.tsx
+++ b/app/venues/[id]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { CalendarDays, Clock, MapPin, Twitter, Instagram, Globe, Ticket } from "lucide-react"
 import { venues, events } from "@/lib/data"
+import { Price } from "@/components/price"
 import { Card, CardContent } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Button } from "@/components/ui/button"
@@ -87,9 +88,11 @@ export default function VenuePage({ params }: { params: { id: string } }) {
                           <span className="bg-purple-600 text-white px-3 py-1 rounded-full text-xs font-medium">
                             {event.category}
                           </span>
-                          <span className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium">
-                            {event.price} ETH
-                          </span>
+                          <Price
+                            usd={event.priceUsd}
+                            eth={event.priceEth}
+                            className="bg-slate-900 bg-opacity-80 text-white px-3 py-1 rounded-full text-xs font-medium"
+                          />
                         </div>
                       </div>
                     </div>

--- a/components/price.tsx
+++ b/components/price.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { useWallet } from "@/context/wallet-context"
+import clsx from "clsx"
+
+export function Price({ usd, eth, className }: { usd: number; eth: number; className?: string }) {
+  const { isConnected } = useWallet()
+  const usdText = `$${usd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+  const formatted = isConnected ? `${usdText} / ${eth} ETH` : usdText
+  return <span className={clsx(className)}>{formatted}</span>
+}

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -5,7 +5,17 @@ export interface Event {
   time: string
   location: string
   category: string
-  price: number
+  /**
+   * Price of the event ticket in USD. This value is pre‑converted from the
+   * original cryptocurrency price so that the frontend can display USD by
+   * default.
+   */
+  priceUsd: number
+  /**
+   * Original price in Ether. Shown alongside the USD price when a wallet is
+   * connected.
+   */
+  priceEth: number
   image: string
   soldTickets: number
   totalTickets: number
@@ -110,7 +120,8 @@ export const events: Event[] = [
     time: "10:00 AM",
     location: "San Francisco, CA",
     category: "Conference",
-    price: 0.15,
+    priceUsd: 450,
+    priceEth: 0.15,
     image: "https://www.cryptotimes.io/wp-content/uploads/2025/03/DC-BLOCKCHAIN-SUMMIT-2025.jpg",
     soldTickets: 156,
     totalTickets: 200,
@@ -124,7 +135,8 @@ export const events: Event[] = [
     time: "6:00 PM",
     location: "New York, NY",
     category: "Exhibition",
-    price: 0.08,
+    priceUsd: 240,
+    priceEth: 0.08,
     image: "https://www.tokyoweekender.com/wp-content/uploads/2021/07/CrypTOKYO-Press-Preview-and-VIP-invite-2-1.jpg",
     soldTickets: 89,
     totalTickets: 150,
@@ -138,7 +150,8 @@ export const events: Event[] = [
     time: "4:00 PM",
     location: "Miami, FL",
     category: "Festival",
-    price: 0.25,
+    priceUsd: 750,
+    priceEth: 0.25,
     image: "https://www.billboard.com/wp-content/uploads/2022/03/BILLBOARD-BLOCKCHAIN-02-b-Explainer-Shira-Inbar-1548.jpg?w=681&h=383&crop=1",
     soldTickets: 412,
     totalTickets: 500,
@@ -152,7 +165,8 @@ export const events: Event[] = [
     time: "9:00 AM",
     location: "Austin, TX",
     category: "Conference",
-    price: 0.12,
+    priceUsd: 360,
+    priceEth: 0.12,
     image: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSuAdxCvhlZ3iQmT_guNOl6ipJ3SoFpKDvYjT9l4YTIgMFrCA6rzn2M7uIv1__7rjjLzTI&usqp=CAU",
     soldTickets: 78,
     totalTickets: 300,
@@ -166,7 +180,8 @@ export const events: Event[] = [
     time: "8:00 PM",
     location: "Los Angeles, CA",
     category: "Concert",
-    price: 0.18,
+    priceUsd: 540,
+    priceEth: 0.18,
     image: "https://images.theconversation.com/files/414962/original/file-20210806-17-jibbct.jpg?ixlib=rb-4.1.0&rect=0%2C5%2C2000%2C1116&q=20&auto=format&w=320&fit=clip&dpr=2&usm=12&cs=strip",
     soldTickets: 245,
     totalTickets: 400,
@@ -180,7 +195,8 @@ export const events: Event[] = [
     time: "2:00 PM",
     location: "Seattle, WA",
     category: "Gaming",
-    price: 0.05,
+    priceUsd: 150,
+    priceEth: 0.05,
     image: "https://venturebeat.com/wp-content/uploads/2021/03/article23-1.jpg",
     soldTickets: 120,
     totalTickets: 250,


### PR DESCRIPTION
## Summary
- convert event pricing to USD in `lib/data.ts`
- add `Price` component for showing USD by default and ETH when wallet connected
- update all pages to use the USD price and show ETH when wallet connected

## Testing
- `npm install`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68751dabc89c83289d75971bd68c6d8c